### PR TITLE
PATCH  Release - [S-110135] - Fix for encoded appName and supporting slash in instance URL

### DIFF
--- a/plugins/dai-deploy-backend/src/api/apiConfig.ts
+++ b/plugins/dai-deploy-backend/src/api/apiConfig.ts
@@ -25,7 +25,7 @@ export const getCredentials = (config: Config) => {
 export const getDeployApiHost = (config: Config): string => {
   try {
     const validHost = config.getString('daiDeploy.host');
-    return `${validHost}`;
+    return `${removeTrailingSlash(validHost)}`;
   } catch (error: unknown) {
     throw new Error(`Error: ${(error as Error).message}`);
   }
@@ -34,6 +34,12 @@ export const getDeployApiHost = (config: Config): string => {
 export const getEncodedQueryVal = (queryString?: string): string => {
   return encodeURIComponent(
     queryString || queryString === 'undefined' ? queryString : '',
+  );
+};
+
+export const getDecodedQueryVal = (queryString?: string): string => {
+  return decodeURIComponent(
+      queryString || queryString === 'undefined' ? queryString : '',
   );
 };
 
@@ -57,3 +63,7 @@ export const getDeploymentHistoryRedirectUri = (
 ): string => {
   return `${getDeployApiHost(config)}${DEPLOYMENT_HISTORY_TASK_DETAILS_REDIRECT_PATH}${taskId}`;
 };
+
+function removeTrailingSlash(input: string): string {
+  return input.endsWith('/') ? input.slice(0, -1) : input;
+}

--- a/plugins/dai-deploy-backend/src/service/router.ts
+++ b/plugins/dai-deploy-backend/src/service/router.ts
@@ -11,6 +11,7 @@ import {
   daiDeployPermissions,
   daiDeployViewPermission,
 } from '@digital-ai/plugin-dai-deploy-common';
+import {getDecodedQueryVal, getEncodedQueryVal} from '../api/apiConfig';
 import { Config } from '@backstage/config';
 import { DeploymentHistoryStatusApi } from '../api';
 import { Logger } from 'winston';
@@ -19,7 +20,6 @@ import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-
 import { errorHandler } from '@backstage/backend-common';
 import express from 'express';
 import { getBearerTokenFromAuthorizationHeader } from '@backstage/plugin-auth-node';
-import { getEncodedQueryVal } from '../api/apiConfig';
 import { stringifyEntityRef } from '@backstage/catalog-model';
 
 export interface RouterOptions {
@@ -91,7 +91,7 @@ export async function createRouter(
       }
     }
 
-    const appName = getEncodedQueryVal(req.query.appName?.toString());
+    const appName = getDecodedQueryVal(req.query.appName?.toString());
     const beginDate = getEncodedQueryVal(req.query.beginDate?.toString());
     const endDate = getEncodedQueryVal(req.query.endDate?.toString());
     const order = getEncodedQueryVal(req.query.order?.toString());
@@ -138,7 +138,7 @@ export async function createRouter(
         );
       }
     }
-    const appName = getEncodedQueryVal(req.query.appName?.toString());
+    const appName = getDecodedQueryVal(req.query.appName?.toString());
     const beginDate = getEncodedQueryVal(req.query.beginDate?.toString());
     const endDate = getEncodedQueryVal(req.query.endDate?.toString());
     const order = getEncodedQueryVal(req.query.order?.toString());


### PR DESCRIPTION
Defects fixed
1. Noticed an issue in deploy plugin. Whenever we have the ci id with space our plugin doesnt work. It doesnt pull data. Eg. We are using SatelliteApp for testing but the name is "Satellite App" then our plugin fails to pull data. Its because of encoding the URL from front end to backend which makes "Satellite App" to "Satellite%20App" where our request goes with this and it doesnt find data for this CI.
2. If host name has / in instance details like 'https://xl-deploy.xebialabs.com/', we get instance/service not found error. / should be removed from hostname if present before sending request to deploy.

## Release Checklist

- All steps below must be completed before merging.

## Author Checklist
### Required
- [x] PR title should follow the correct format.
- [x] Checklist of **changes made** added to PR description
- [x] Related issue(s) linked to PR
 
## Reviewer Checklist
- [ ] Author checklist has been reviewed?
- [ ] All acceptance criteria have been met from the linked issue
- [ ] Run code locally and verify all changes


## Related Issue(s)

Resolves #XXXX
Story-
Defect-
D-34396 - Deploy plugin not getting data if Application name has space and / in hotsname throws service down error