### PR TITLE
PATCH - S-111245 - Library upgrade for Deploy Plugin

### DIFF
--- a/plugins/dai-deploy-backend/CHANGE_LOG.md
+++ b/plugins/dai-deploy-backend/CHANGE_LOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+## [v0.1.5](https://github.com/digital-ai/backstage-deploy/tree/dai-deploy-backend/v0.1.5) (17/10/2024)
+
+### Library upgrade
+
+- Replaced winston logger with LoggerService
+- Replaced PermissionEvaluator to PermissionService
+- Removed permission support for old backend system
+- Updated dependencies
+  - @backstage/backend-common@^0.25.0
+  - @backstage/backend-plugin-api@^1.0.1
+  - @backstage/catalog-model@^1.7.0
+  - @backstage/config@^1.2.0
+  - @backstage/errors@^1.2.4
+  - @backstage/plugin-auth-node@^0.5.3
+  - @backstage/plugin-permission-common@^0.8.1
+  - @backstage/plugin-permission-node@^0.8.4
+  - @backstage/test-utils@^1.5.10
+  - @backstage/backend-test-utils@^1.0.1
+  - @backstage/backend-defaults@^0.5.1
+  - @digital-ai/plugin-dai-deploy-common@0.1.2
+  - express@^4.21.1
+  - express-promise-router@^4.1.1
+  - node-fetch@^3.3.2
+  - yn@^5.0.0
+  - @backstage/cli@^0.28.0
+  - @spotify/prettier-config@^15.0.0
+  - @types/supertest@^6.0.2
+  - husky@^9.1.6
+  - lint-staged@^15.2.10
+  - msw@^2.4.11
+  - prettier@3.3.3
+  - supertest@^7.0.0

--- a/plugins/dai-deploy-backend/package.json
+++ b/plugins/dai-deploy-backend/package.json
@@ -85,6 +85,5 @@
       "eslint --fix",
       "prettier --write --ignore-unknown"
     ]
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/plugins/dai-deploy-backend/package.json
+++ b/plugins/dai-deploy-backend/package.json
@@ -60,7 +60,7 @@
     "@backstage/test-utils": "^1.5.10",
     "@backstage/backend-test-utils": "^1.0.1",
     "@backstage/backend-defaults": "^0.5.1",
-    "@digital-ai/plugin-dai-deploy-common": "0.1.2",
+    "@digital-ai/plugin-dai-deploy-common": "0.1.3-alpha-0",
     "@types/express": "*",
     "express": "^4.21.1",
     "express-promise-router": "^4.1.1",

--- a/plugins/dai-deploy-backend/package.json
+++ b/plugins/dai-deploy-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@digital-ai/plugin-dai-deploy-backend",
   "description": "Backend functionalities for the dai-deploy backstage plugin",
-  "version": "0.1.5-alpha-0",
+  "version": "0.1.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "MIT",
@@ -60,7 +60,7 @@
     "@backstage/test-utils": "^1.5.10",
     "@backstage/backend-test-utils": "^1.0.1",
     "@backstage/backend-defaults": "^0.5.1",
-    "@digital-ai/plugin-dai-deploy-common": "0.1.3-alpha-0",
+    "@digital-ai/plugin-dai-deploy-common": "0.1.2",
     "@types/express": "*",
     "express": "^4.21.1",
     "express-promise-router": "^4.1.1",

--- a/plugins/dai-deploy-backend/package.json
+++ b/plugins/dai-deploy-backend/package.json
@@ -11,11 +11,16 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "role": "backend-plugin"
+    "role": "backend-plugin",
+    "pluginId": "dai-deploy",
+    "pluginPackages": [
+      "@digital-ai/plugin-dai-deploy-backend"
+    ]
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/digital-ai/backstage-deploy.git"
+    "url": "git://github.com/digital-ai/backstage-deploy.git",
+    "directory": "."
   },
   "bugs": {
     "url": "https://github.com/digital-ai/backstage-deploy/issues"
@@ -40,34 +45,37 @@
     "postpack": "backstage-cli package postpack",
     "prepare": "husky",
     "prettier:check": "prettier --check .",
-    "prettier:fix": "prettier --write ."
+    "prettier:fix": "prettier --write .",
+    "fix": "backstage-cli repo fix --publish"
   },
   "dependencies": {
-    "@backstage/backend-common": "^0.19.5",
-    "@backstage/backend-plugin-api": "^0.6.12",
-    "@backstage/catalog-model": "^1.4.4",
-    "@backstage/config": "^1.1.0",
-    "@backstage/errors": "^1.2.3",
-    "@backstage/plugin-auth-node": "^0.4.8",
-    "@backstage/plugin-permission-common": "^0.7.12",
-    "@backstage/plugin-permission-node": "^0.7.24",
+    "@backstage/backend-common": "^0.25.0",
+    "@backstage/backend-plugin-api": "^1.0.1",
+    "@backstage/catalog-model": "^1.7.0",
+    "@backstage/config": "^1.2.0",
+    "@backstage/errors": "^1.2.4",
+    "@backstage/plugin-auth-node": "^0.5.3",
+    "@backstage/plugin-permission-common": "^0.8.1",
+    "@backstage/plugin-permission-node": "^0.8.4",
+    "@backstage/test-utils": "^1.5.10",
+    "@backstage/backend-test-utils": "^1.0.1",
+    "@backstage/backend-defaults": "^0.5.1",
     "@digital-ai/plugin-dai-deploy-common": "0.1.2",
     "@types/express": "*",
-    "express": "^4.17.1",
-    "express-promise-router": "^4.1.0",
-    "node-fetch": "^2.6.7",
-    "winston": "^3.2.1",
-    "yn": "^4.0.0"
+    "express": "^4.21.1",
+    "express-promise-router": "^4.1.1",
+    "node-fetch": "^3.3.2",
+    "yn": "^5.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.22.13",
+    "@backstage/cli": "^0.28.0",
     "@spotify/prettier-config": "^15.0.0",
-    "@types/supertest": "^2.0.12",
-    "husky": "^9.0.11",
-    "lint-staged": "^15.2.2",
-    "msw": "^2.2.1",
-    "prettier": "3.2.5",
-    "supertest": "^6.2.4"
+    "@types/supertest": "^6.0.2",
+    "husky": "^9.1.6",
+    "lint-staged": "^15.2.10",
+    "msw": "^2.4.11",
+    "prettier": "3.3.3",
+    "supertest": "^7.0.0"
   },
   "files": [
     "dist"
@@ -77,5 +85,6 @@
       "eslint --fix",
       "prettier --write --ignore-unknown"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/plugins/dai-deploy-backend/package.json
+++ b/plugins/dai-deploy-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@digital-ai/plugin-dai-deploy-backend",
   "description": "Backend functionalities for the dai-deploy backstage plugin",
-  "version": "0.1.4",
+  "version": "0.1.5-alpha-0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "MIT",

--- a/plugins/dai-deploy-backend/src/api/Api.test.ts
+++ b/plugins/dai-deploy-backend/src/api/Api.test.ts
@@ -17,7 +17,7 @@ import {
 import { CurrentDeploymentStatusApi } from './CurrentDeploymentStatusApi';
 import { DeploymentHistoryStatusApi } from './DeploymentHistoryStatusApi';
 import { DeploymentStatusResponse } from '@digital-ai/plugin-dai-deploy-common';
-import { getVoidLogger } from '@backstage/backend-common';
+import { mockServices } from "@backstage/backend-test-utils";
 
 function configureMockServer(): SetupServerApi {
   const server = setupServer();
@@ -48,7 +48,7 @@ describe('Backend API tests for Current Deployment Status', () => {
   it('Should throw error if config hostname is empty', async () => {
     const currentDeploymentStatusApi = CurrentDeploymentStatusApi.fromConfig(
       configWithEmptyHost,
-      getVoidLogger(),
+      mockServices.logger.mock(),
     );
 
     await expect(
@@ -70,7 +70,7 @@ describe('Backend API tests for Current Deployment Status', () => {
   it('Should throw error if config username is empty', async () => {
     const currentDeploymentStatusApi = CurrentDeploymentStatusApi.fromConfig(
       configWithEmptyUsername,
-      getVoidLogger(),
+      mockServices.logger.mock(),
     );
 
     await expect(
@@ -92,7 +92,7 @@ describe('Backend API tests for Current Deployment Status', () => {
   it('Should throw error if config password is empty', async () => {
     const currentDeploymentStatusApi = CurrentDeploymentStatusApi.fromConfig(
       configWithEmptyPassword,
-      getVoidLogger(),
+      mockServices.logger.mock(),
     );
 
     await expect(
@@ -114,7 +114,7 @@ describe('Backend API tests for Current Deployment Status', () => {
   it('Should get current deployment status from Deploy API', async () => {
     const currentDeploymentStatusApi = CurrentDeploymentStatusApi.fromConfig(
       config,
-      getVoidLogger(),
+      mockServices.logger.mock(),
     );
 
     const deploymentStatusResponse: DeploymentStatusResponse =
@@ -141,7 +141,7 @@ describe('Backend API tests for Current Deployment Status', () => {
 
     const currentDeploymentStatusApi = CurrentDeploymentStatusApi.fromConfig(
       config,
-      getVoidLogger(),
+      mockServices.logger.mock(),
     );
 
     await expect(
@@ -163,7 +163,7 @@ describe('Backend API tests for Current Deployment Status', () => {
 
     const currentDeploymentStatusApi = CurrentDeploymentStatusApi.fromConfig(
       config,
-      getVoidLogger(),
+      mockServices.logger.mock(),
     );
 
     await expect(
@@ -186,7 +186,7 @@ describe('Backend API tests for Current Deployment Status', () => {
 
     const currentDeploymentStatusApi = CurrentDeploymentStatusApi.fromConfig(
       config,
-      getVoidLogger(),
+      mockServices.logger.mock(),
     );
 
     await expect(
@@ -208,7 +208,7 @@ describe('Backend API tests for Current Deployment Status', () => {
 
     const currentDeploymentStatusApi = CurrentDeploymentStatusApi.fromConfig(
       config,
-      getVoidLogger(),
+      mockServices.logger.mock(),
     );
     await expect(
       async () =>
@@ -232,7 +232,7 @@ describe('Backend API tests for Deployment History Status', () => {
   it('Should throw error if config hostname is empty', async () => {
     const deploymentHistoryStatusApi = DeploymentHistoryStatusApi.fromConfig(
       configWithEmptyHost,
-      getVoidLogger(),
+      mockServices.logger.mock(),
     );
 
     await expect(
@@ -254,7 +254,7 @@ describe('Backend API tests for Deployment History Status', () => {
   it('Should throw error if config username is empty', async () => {
     const deploymentHistoryStatusApi = DeploymentHistoryStatusApi.fromConfig(
       configWithEmptyUsername,
-      getVoidLogger(),
+      mockServices.logger.mock(),
     );
 
     await expect(
@@ -276,7 +276,7 @@ describe('Backend API tests for Deployment History Status', () => {
   it('Should throw error if config password is empty', async () => {
     const deploymentHistoryStatusApi = DeploymentHistoryStatusApi.fromConfig(
       configWithEmptyPassword,
-      getVoidLogger(),
+      mockServices.logger.mock(),
     );
 
     await expect(
@@ -298,7 +298,7 @@ describe('Backend API tests for Deployment History Status', () => {
   it('Should get deployment History from Deploy API', async () => {
     const deploymentHistoryStatusApi = DeploymentHistoryStatusApi.fromConfig(
       config,
-      getVoidLogger(),
+      mockServices.logger.mock(),
     );
 
     const deploymentStatusResponse: DeploymentStatusResponse =
@@ -325,7 +325,7 @@ describe('Backend API tests for Deployment History Status', () => {
 
     const deploymentHistoryStatusApi = DeploymentHistoryStatusApi.fromConfig(
       config,
-      getVoidLogger(),
+      mockServices.logger.mock(),
     );
 
     await expect(
@@ -347,7 +347,7 @@ describe('Backend API tests for Deployment History Status', () => {
 
     const deploymentHistoryStatusApi = DeploymentHistoryStatusApi.fromConfig(
       config,
-      getVoidLogger(),
+      mockServices.logger.mock(),
     );
 
     await expect(
@@ -371,7 +371,7 @@ describe('Backend API tests for Deployment History Status', () => {
 
     const deploymentHistoryStatusApi = DeploymentHistoryStatusApi.fromConfig(
       config,
-      getVoidLogger(),
+      mockServices.logger.mock(),
     );
 
     await expect(
@@ -393,7 +393,7 @@ describe('Backend API tests for Deployment History Status', () => {
 
     const deploymentHistoryStatusApi = DeploymentHistoryStatusApi.fromConfig(
       config,
-      getVoidLogger(),
+      mockServices.logger.mock(),
     );
 
     await expect(

--- a/plugins/dai-deploy-backend/src/api/CurrentDeploymentStatusApi.ts
+++ b/plugins/dai-deploy-backend/src/api/CurrentDeploymentStatusApi.ts
@@ -11,19 +11,19 @@ import {
   DeploymentStatusResponse,
 } from '@digital-ai/plugin-dai-deploy-common';
 import { Config } from '@backstage/config';
-import { Logger } from 'winston';
+import { RootLoggerService } from "@backstage/backend-plugin-api";
 import { parseErrorResponse } from './responseUtil';
 
 export class CurrentDeploymentStatusApi {
-  private readonly logger: Logger;
+  private readonly logger: RootLoggerService;
   private readonly config: Config;
 
-  private constructor(logger: Logger, config: Config) {
+  private constructor(logger: RootLoggerService, config: Config) {
     this.logger = logger;
     this.config = config;
   }
 
-  static fromConfig(config: Config, logger: Logger) {
+  static fromConfig(config: Config, logger: RootLoggerService) {
     return new CurrentDeploymentStatusApi(logger, config);
   }
 

--- a/plugins/dai-deploy-backend/src/api/DeployedApplicationStatusApi.ts
+++ b/plugins/dai-deploy-backend/src/api/DeployedApplicationStatusApi.ts
@@ -5,19 +5,19 @@ import {
 } from './apiConfig';
 import { Config } from '@backstage/config';
 import { DeployedApplicationStatus } from '@digital-ai/plugin-dai-deploy-common';
-import { Logger } from 'winston';
+import { RootLoggerService } from "@backstage/backend-plugin-api";
 
 /** @public */
 export class DeployedApplicationStatusApi {
-  private readonly logger: Logger;
+  private readonly logger: RootLoggerService;
   private readonly config: Config;
 
-  private constructor(logger: Logger, config: Config) {
+  private constructor(logger: RootLoggerService, config: Config) {
     this.logger = logger;
     this.config = config;
   }
 
-  static fromConfig(config: Config, logger: Logger) {
+  static fromConfig(config: Config, logger: RootLoggerService) {
     return new DeployedApplicationStatusApi(logger, config);
   }
 

--- a/plugins/dai-deploy-backend/src/api/DeploymentHistoryStatusApi.ts
+++ b/plugins/dai-deploy-backend/src/api/DeploymentHistoryStatusApi.ts
@@ -11,19 +11,19 @@ import {
   DeploymentStatusResponse,
 } from '@digital-ai/plugin-dai-deploy-common';
 import { Config } from '@backstage/config';
-import { Logger } from 'winston';
+import { RootLoggerService } from "@backstage/backend-plugin-api";
 import { parseErrorResponse } from './responseUtil';
 
 export class DeploymentHistoryStatusApi {
-  private readonly logger: Logger;
+  private readonly logger: RootLoggerService;
   private readonly config: Config;
 
-  private constructor(logger: Logger, config: Config) {
+  private constructor(logger: RootLoggerService, config: Config) {
     this.logger = logger;
     this.config = config;
   }
 
-  static fromConfig(config: Config, logger: Logger) {
+  static fromConfig(config: Config, logger: RootLoggerService) {
     return new DeploymentHistoryStatusApi(logger, config);
   }
 

--- a/plugins/dai-deploy-backend/src/api/responseUtil.ts
+++ b/plugins/dai-deploy-backend/src/api/responseUtil.ts
@@ -3,9 +3,9 @@ import {
   NotAllowedError,
   NotFoundError,
 } from '@backstage/errors';
-import { Logger } from 'winston';
+import { RootLoggerService } from "@backstage/backend-plugin-api";
 
-export async function parseErrorResponse(logger: Logger, response: Response) {
+export async function parseErrorResponse(logger: RootLoggerService, response: Response) {
   logger?.error(
     `Error occurred while accessing deploy: status: ${response.status}, statusText: ${response.statusText} `,
   );

--- a/plugins/dai-deploy-backend/src/plugin.ts
+++ b/plugins/dai-deploy-backend/src/plugin.ts
@@ -3,7 +3,6 @@ import {
   createBackendPlugin,
 } from '@backstage/backend-plugin-api';
 import { createRouter } from './service/router';
-import { loggerToWinstonLogger } from '@backstage/backend-common';
 
 /**
  * Digital.ai Deploy backend plugin
@@ -16,15 +15,17 @@ export const daiDeployPlugin = createBackendPlugin({
     env.registerInit({
       deps: {
         config: coreServices.rootConfig,
-        logger: coreServices.logger,
+        logger: coreServices.rootLogger,
         httpRouter: coreServices.httpRouter,
+        httpAuth: coreServices.httpAuth,
         permissions: coreServices.permissions,
       },
-      async init({ config, logger, httpRouter, permissions }) {
+      async init({ config, logger, httpRouter, httpAuth, permissions }) {
         httpRouter.use(
           await createRouter({
             config,
-            logger: loggerToWinstonLogger(logger),
+            logger: logger,
+            httpAuth,
             permissions,
           }),
         );

--- a/plugins/dai-deploy-backend/src/service/router.test.ts
+++ b/plugins/dai-deploy-backend/src/service/router.test.ts
@@ -1,7 +1,7 @@
 import {
-  AuthorizeResult,
-  PermissionEvaluator,
-} from '@backstage/plugin-permission-common';
+  HttpAuthService,
+  PermissionsService,
+} from '@backstage/backend-plugin-api';
 import {
   config,
   currentDeploymentBackendApiResponse,
@@ -13,9 +13,10 @@ import {
   error500ResponseHandler,
   mockTestHandlers,
 } from '../mocks/mock.test.handlers';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { createRouter } from './router';
 import express from 'express';
-import { getVoidLogger } from '@backstage/backend-common';
+import { mockServices } from '@backstage/backend-test-utils';
 import request from 'supertest';
 import { setupServer } from 'msw/node';
 
@@ -23,7 +24,7 @@ let app: express.Express;
 const permissionApi = {
   authorize: jest.fn(),
   authorizeConditional: jest.fn(),
-} as unknown as PermissionEvaluator;
+} as unknown as PermissionsService;
 
 function configureMockServer(permission: boolean) {
   const server = setupServer();
@@ -32,14 +33,18 @@ function configureMockServer(permission: boolean) {
     if (permission) {
       const router = await createRouter({
         config,
-        logger: getVoidLogger(),
+        logger: mockServices.logger.mock(),
+        httpAuth: {
+          credentials: jest.fn().mockResolvedValue({}),
+        } as unknown as HttpAuthService,
         permissions: permissionApi,
       });
       app = express().use(router);
     } else {
       const router = await createRouter({
         config,
-        logger: getVoidLogger(),
+        logger: mockServices.logger.mock(),
+        httpAuth: mockServices.httpAuth.mock(),
       });
       app = express().use(router);
     }

--- a/plugins/dai-deploy-backend/src/service/router.ts
+++ b/plugins/dai-deploy-backend/src/service/router.ts
@@ -1,37 +1,37 @@
 import {
-  AuthorizeResult,
-  PermissionEvaluator,
-} from '@backstage/plugin-permission-common';
-import {
   CurrentDeploymentStatusApi,
   DeployedApplicationStatusApi,
 } from '../api';
+import {
+  HttpAuthService, LoggerService,
+  PermissionsService,
+} from '@backstage/backend-plugin-api';
 import { InputError, NotAllowedError } from '@backstage/errors';
 import {
   daiDeployPermissions,
   daiDeployViewPermission,
 } from '@digital-ai/plugin-dai-deploy-common';
 import {getDecodedQueryVal, getEncodedQueryVal} from '../api/apiConfig';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { Config } from '@backstage/config';
 import { DeploymentHistoryStatusApi } from '../api';
-import { Logger } from 'winston';
+import { MiddlewareFactory } from "@backstage/backend-defaults/rootHttpRouter";
 import Router from 'express-promise-router';
 import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';
-import { errorHandler } from '@backstage/backend-common';
 import express from 'express';
-import { getBearerTokenFromAuthorizationHeader } from '@backstage/plugin-auth-node';
 import { stringifyEntityRef } from '@backstage/catalog-model';
 
 export interface RouterOptions {
   config: Config;
-  logger: Logger;
-  permissions?: PermissionEvaluator;
+  logger: LoggerService;
+  permissions?: PermissionsService;
+  httpAuth?: HttpAuthService;
 }
 
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const { logger, config, permissions } = options;
+  const { logger, config, permissions, httpAuth } = options;
   const deployedApplicationStatusApi = DeployedApplicationStatusApi.fromConfig(
     config,
     logger,
@@ -66,9 +66,6 @@ export async function createRouter(
 
   router.get('/deployment-status/:namespace/:kind/:name', async (req, res) => {
     const { namespace, kind, name } = req.params;
-    const token = getBearerTokenFromAuthorizationHeader(
-      req.header('authorization'),
-    );
     const entityRef = stringifyEntityRef({
       kind,
       namespace,
@@ -78,10 +75,10 @@ export async function createRouter(
       throw new InputError('Invalid entityRef, not a string');
     }
 
-    if (permissions) {
+    if (permissions && httpAuth) {
       const decision = await permissions.authorize(
         [{ permission: daiDeployViewPermission, resourceRef: entityRef }],
-        { token },
+        { credentials: await httpAuth.credentials(req) },
       );
       const { result } = decision[0];
       if (result === AuthorizeResult.DENY) {
@@ -115,9 +112,6 @@ export async function createRouter(
 
   router.get('/deployment-history/:namespace/:kind/:name', async (req, res) => {
     const { namespace, kind, name } = req.params;
-    const token = getBearerTokenFromAuthorizationHeader(
-      req.header('authorization'),
-    );
     const entityRef = stringifyEntityRef({
       kind,
       namespace,
@@ -126,10 +120,10 @@ export async function createRouter(
     if (typeof entityRef !== 'string') {
       throw new InputError('Invalid entityRef, not a string');
     }
-    if (permissions) {
+    if (permissions && httpAuth) {
       const decision = await permissions.authorize(
         [{ permission: daiDeployViewPermission, resourceRef: entityRef }],
-        { token },
+        { credentials: await httpAuth.credentials(req) },
       );
       const { result } = decision[0];
       if (result === AuthorizeResult.DENY) {
@@ -160,6 +154,7 @@ export async function createRouter(
     res.status(200).json(deploymentHistoryStatus);
   });
 
-  router.use(errorHandler());
+  const middleware = MiddlewareFactory.create({ logger, config });
+  router.use(middleware.error());
   return router;
 }

--- a/plugins/dai-deploy-backend/src/service/standaloneServer.ts
+++ b/plugins/dai-deploy-backend/src/service/standaloneServer.ts
@@ -4,15 +4,16 @@ import {
   createServiceBuilder,
   loadBackendConfig,
 } from '@backstage/backend-common';
-import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { Server } from 'http';
 import { ServerPermissionClient } from '@backstage/plugin-permission-node';
 import { createRouter } from './router';
+import { mockServices } from "@backstage/backend-test-utils";
 
 export interface ServerOptions {
   port: number;
   enableCors: boolean;
-  logger: Logger;
+  logger: LoggerService;
 }
 
 export async function startStandaloneServer(
@@ -28,10 +29,13 @@ export async function startStandaloneServer(
     discovery,
     tokenManager,
   });
+  const httpAuth = mockServices.httpAuth({pluginId: 'dai-deploy'});
+  
   logger.debug('Starting application server...');
   const router = await createRouter({
     config,
     logger,
+    httpAuth,
     permissions,
   });
 

--- a/plugins/dai-deploy-common/CHANGE_LOG.md
+++ b/plugins/dai-deploy-common/CHANGE_LOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## [v0.1.3](https://github.com/digital-ai/backstage-deploy/tree/dai-deploy-common/v0.1.3) (17/10/2024)
+
+### Library upgrade
+
+- Replaced winston logger with LoggerService
+- Replaced PermissionEvaluator to PermissionService
+- Removed permission support for old backend system
+- Updated dependencies
+  - @backstage/cli@^0.28.0
+  - husky@^9.1.6
+  - prettier@^15.2.10
+  - @backstage/plugin-catalog-common@^1.1.0
+  - @backstage/plugin-permission-common@^0.8.1
+  - @backstage/plugin-permission-node@^0.8.4

--- a/plugins/dai-deploy-common/CHANGE_LOG.md
+++ b/plugins/dai-deploy-common/CHANGE_LOG.md
@@ -7,7 +7,7 @@
 - Updated dependencies
   - @backstage/cli@^0.28.0
   - husky@^9.1.6
-  - prettier@^15.2.10
+  - prettier@^3.3.3
   - @backstage/plugin-catalog-common@^1.1.0
   - @backstage/plugin-permission-common@^0.8.1
   - @backstage/plugin-permission-node@^0.8.4

--- a/plugins/dai-deploy-common/CHANGE_LOG.md
+++ b/plugins/dai-deploy-common/CHANGE_LOG.md
@@ -4,9 +4,6 @@
 
 ### Library upgrade
 
-- Replaced winston logger with LoggerService
-- Replaced PermissionEvaluator to PermissionService
-- Removed permission support for old backend system
 - Updated dependencies
   - @backstage/cli@^0.28.0
   - husky@^9.1.6

--- a/plugins/dai-deploy-common/package.json
+++ b/plugins/dai-deploy-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@digital-ai/plugin-dai-deploy-common",
   "description": "Common functionalities for the dai-deploy plugin",
-  "version": "0.1.3-alpha-0",
+  "version": "0.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "MIT",

--- a/plugins/dai-deploy-common/package.json
+++ b/plugins/dai-deploy-common/package.json
@@ -44,11 +44,11 @@
     "prettier:fix": "prettier --write ."
   },
   "devDependencies": {
-    "@backstage/cli": "^0.22.13",
+    "@backstage/cli": "^0.28.0",
     "@spotify/prettier-config": "^15.0.0",
-    "husky": "^9.0.11",
+    "husky": "^9.1.6",
     "lint-staged": "^15.2.2",
-    "prettier": "3.2.5"
+    "prettier": "^15.2.10"
   },
   "files": [
     "dist"
@@ -60,8 +60,9 @@
     ]
   },
   "dependencies": {
-    "@backstage/plugin-catalog-common": "^1.0.21",
-    "@backstage/plugin-permission-common": "^0.7.12",
-    "@backstage/plugin-permission-node": "^0.7.23"
-  }
+    "@backstage/plugin-catalog-common": "^1.1.0",
+    "@backstage/plugin-permission-common": "^0.8.1",
+    "@backstage/plugin-permission-node": "^0.8.4"
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/plugins/dai-deploy-common/package.json
+++ b/plugins/dai-deploy-common/package.json
@@ -63,6 +63,5 @@
     "@backstage/plugin-catalog-common": "^1.1.0",
     "@backstage/plugin-permission-common": "^0.8.1",
     "@backstage/plugin-permission-node": "^0.8.4"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/plugins/dai-deploy-common/package.json
+++ b/plugins/dai-deploy-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@digital-ai/plugin-dai-deploy-common",
   "description": "Common functionalities for the dai-deploy plugin",
-  "version": "0.1.2",
+  "version": "0.1.3-alpha-0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "MIT",

--- a/plugins/dai-deploy-common/package.json
+++ b/plugins/dai-deploy-common/package.json
@@ -48,7 +48,7 @@
     "@spotify/prettier-config": "^15.0.0",
     "husky": "^9.1.6",
     "lint-staged": "^15.2.2",
-    "prettier": "^15.2.10"
+    "prettier": "^3.3.3"
   },
   "files": [
     "dist"

--- a/plugins/dai-deploy/CHANGE_LOG.md
+++ b/plugins/dai-deploy/CHANGE_LOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+## [v0.1.3](https://github.com/digital-ai/backstage-deploy/tree/dai-deploy/v0.1.3) (17/10/2024)
+
+### Library upgrade
+
+- Updated dependencies
+  - @backstage/catalog-model@^1.7.0 
+  - @backstage/core-components@^0.15.1 
+  - @backstage/core-plugin-api@^1.10.0 
+  - @backstage/errors@^1.2.4 
+  - @backstage/plugin-catalog-react@^1.14.0 
+  - @backstage/plugin-permission-react@^0.4.27 
+  - @backstage/theme@^0.6.0",
+  - @material-ui/core@^4.12.4
+  - @material-ui/icons@^4.11.3
+  - react-use@^17.5.1
+  - react@^16.13.1 || ^17.0.0 || ^18.0.2
+  - react-dom@^16.13.1 || ^17.0.0 || ^18.0.2
+  - react-router-dom@6.0.0-beta.0 || ^6.3.0
+  - @backstage/cli@^0.28.0"
+  - @backstage/core-app-api@^1.15.1
+  - @backstage/dev-utils@^1.1.2
+  - @backstage/test-utils@^1.7.0 
+  - @testing-library/jest-dom@^6.6.1
+  - @testing-library/react@^16.0.1 
+  - @testing-library/user-event@^14.5.2 
+  - husky@^9.1.6 
+  - lint-staged@^15.2.10 
+  - msw@^1.3.4"
+  - prettier@3.3.3
+  - typescript@~5.6.3
+  - @types/react@^18
+  - @types/react-dom@^18

--- a/plugins/dai-deploy/package.json
+++ b/plugins/dai-deploy/package.json
@@ -44,47 +44,49 @@
     "prettier:fix": "prettier --write ."
   },
   "dependencies": {
-    "@backstage/catalog-model": "^1.4.4",
-    "@backstage/core-components": "^0.13.5",
-    "@backstage/core-plugin-api": "^1.6.0",
-    "@backstage/errors": "^1.2.3",
-    "@backstage/plugin-catalog-react": "^1.10.0",
-    "@backstage/plugin-permission-react": "^0.4.20",
-    "@backstage/theme": "^0.4.2",
+    "@backstage/catalog-model": "^1.7.0",
+    "@backstage/core-components": "^0.15.1",
+    "@backstage/core-plugin-api": "^1.10.0",
+    "@backstage/errors": "^1.2.4",
+    "@backstage/plugin-catalog-react": "^1.14.0",
+    "@backstage/plugin-permission-react": "^0.4.27",
+    "@backstage/theme": "^0.6.0",
     "@digital-ai/plugin-dai-deploy-common": "0.1.2",
-    "@material-ui/core": "^4.12.2",
-    "@material-ui/icons": "^4.9.1",
+    "@material-ui/core": "^4.12.4",
+    "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "4.0.0-alpha.61",
     "@mui/material": "^5.15.11",
     "@types/lodash": "^4.14.202",
     "lodash": "^4.17.21",
     "moment": "2.30.1",
-    "react-use": "^17.2.4"
+    "react-use": "^17.5.1"
   },
   "peerDependencies": {
-    "react": "^16.13.1 || ^17.0.0"
+    "react": "^16.13.1 || ^17.0.0 || ^18.0.2",
+    "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.2",
+    "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.22.13",
-    "@backstage/core-app-api": "^1.10.0",
-    "@backstage/dev-utils": "^1.0.21",
-    "@backstage/test-utils": "^1.4.3",
+    "@backstage/cli": "^0.28.0",
+    "@backstage/core-app-api": "^1.15.1",
+    "@backstage/dev-utils": "^1.1.2",
+    "@backstage/test-utils": "^1.7.0",
     "@spotify/prettier-config": "^15.0.0",
-    "@testing-library/jest-dom": "^5.10.1",
-    "@testing-library/react": "^12.1.3",
-    "@testing-library/user-event": "^14.0.0",
-    "husky": "^9.0.11",
-    "lint-staged": "^15.2.2",
-    "msw": "^1.0.0",
-    "prettier": "3.2.5",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-router-dom": "^6.3.0",
-    "typescript": "~5.2.0"
+    "@testing-library/jest-dom": "^6.6.1",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
+    "husky": "^9.1.6",
+    "lint-staged": "^15.2.10",
+    "msw": "^1.3.4",
+    "prettier": "3.3.3",
+    "react": "^16.13.1 || ^17.0.0 || ^18.0.2",
+    "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.2",
+    "react-router-dom": "6.0.0-beta.0 || ^6.3.0",
+    "typescript": "~5.6.3"
   },
   "resolutions": {
-    "@types/react": "^17",
-    "@types/react-dom": "^17"
+    "@types/react": "^18",
+    "@types/react-dom": "^18"
   },
   "files": [
     "dist"
@@ -99,5 +101,6 @@
     "transformIgnorePatterns": [
       "node_modules/(?!(.*))"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/plugins/dai-deploy/package.json
+++ b/plugins/dai-deploy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@digital-ai/plugin-dai-deploy",
   "description": "Frontend functionalities for the dai-deploy backstage plugin",
-  "version": "0.1.3-alpha-0",
+  "version": "0.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "MIT",
@@ -56,7 +56,7 @@
     "@backstage/plugin-catalog-react": "^1.14.0",
     "@backstage/plugin-permission-react": "^0.4.27",
     "@backstage/theme": "^0.6.0",
-    "@digital-ai/plugin-dai-deploy-common": "0.1.3-alpha-0",
+    "@digital-ai/plugin-dai-deploy-common": "0.1.2",
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "4.0.0-alpha.61",

--- a/plugins/dai-deploy/package.json
+++ b/plugins/dai-deploy/package.json
@@ -51,7 +51,7 @@
     "@backstage/plugin-catalog-react": "^1.14.0",
     "@backstage/plugin-permission-react": "^0.4.27",
     "@backstage/theme": "^0.6.0",
-    "@digital-ai/plugin-dai-deploy-common": "0.1.2",
+    "@digital-ai/plugin-dai-deploy-common": "0.1.3-alpha-0",
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "4.0.0-alpha.61",

--- a/plugins/dai-deploy/package.json
+++ b/plugins/dai-deploy/package.json
@@ -11,11 +11,16 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "role": "frontend-plugin"
+    "role": "frontend-plugin",
+    "pluginId": "dai-deploy",
+    "pluginPackages": [
+      "@digital-ai/plugin-dai-deploy"
+    ]
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/digital-ai/backstage-deploy.git"
+    "url": "git://github.com/digital-ai/backstage-deploy.git",
+    "directory": "."
   },
   "bugs": {
     "url": "https://github.com/digital-ai/backstage-deploy/issues"

--- a/plugins/dai-deploy/package.json
+++ b/plugins/dai-deploy/package.json
@@ -75,6 +75,7 @@
     "@testing-library/jest-dom": "^6.6.1",
     "@testing-library/react": "^16.0.1",
     "@testing-library/user-event": "^14.5.2",
+    "@testing-library/dom": "^7.31.2",
     "husky": "^9.1.6",
     "lint-staged": "^15.2.10",
     "msw": "^1.3.4",

--- a/plugins/dai-deploy/package.json
+++ b/plugins/dai-deploy/package.json
@@ -107,6 +107,5 @@
     "transformIgnorePatterns": [
       "node_modules/(?!(.*))"
     ]
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/plugins/dai-deploy/package.json
+++ b/plugins/dai-deploy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@digital-ai/plugin-dai-deploy",
   "description": "Frontend functionalities for the dai-deploy backstage plugin",
-  "version": "0.1.2",
+  "version": "0.1.3-alpha-0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "MIT",


### PR DESCRIPTION
## Release Checklist

What is this Change for: S-111245: Library upgrades - Backstage Deploy Plugin.

**Changes done:**
1) Library upgrades - Backstage Deploy Plugin for dai-deploy-backend, dai-deploy, dai-deploy-common plugins.

**Changes in dai-deploy-backend/package.json updated to the below versions**

**dai-deploy-backend plugin**
- Upgraded backstage libraries to latest version
- Upgraded third party libraries
- Upgraded from PermissionEvaluator to PermissionService
- Upgraded from winston.Logger to LoggerService
- Updated error handler
- Added changelog
- PermissionService support only for New backend system
- Permissions support removed from legacy backend

- Updated dependencies
  - @backstage/backend-common@^0.25.0
  - @backstage/backend-plugin-api@^1.0.1
  - @backstage/catalog-model@^1.7.0
  - @backstage/config@^1.2.0
  - @backstage/errors@^1.2.4
  - @backstage/plugin-auth-node@^0.5.3
  - @backstage/plugin-permission-common@^0.8.1
  - @backstage/plugin-permission-node@^0.8.4
  - @backstage/test-utils@^1.5.10
  - @backstage/backend-test-utils@^1.0.1
  - @backstage/backend-defaults@^0.5.1
  - @digital-ai/plugin-dai-deploy-common@0.1.2
  - express@^4.21.1
  - express-promise-router@^4.1.1
  - node-fetch@^3.3.2
  - yn@^5.0.0
  - @backstage/cli@^0.28.0
  - @spotify/prettier-config@^15.0.0
  - @types/supertest@^6.0.2
  - husky@^9.1.6
  - lint-staged@^15.2.10
  - msw@^2.4.11
  - prettier@3.3.3
  - supertest@^7.0.0

**Changes in dai-deploy-common/package.json**

**dai-deploy-common plugin**
- Upgraded backstage libraries to latest version
- Upgraded third party libraries

- Updated dependencies
  - @backstage/cli@^0.28.0
  - husky@^9.1.6
  - prettier@^15.2.10
  - @backstage/plugin-catalog-common@^1.1.0
  - @backstage/plugin-permission-common@^0.8.1
  - @backstage/plugin-permission-node@^0.8.4
**Changes in dai-deploy/package.json**

**dai-deploy plugin**
- Upgraded backstage libraries to latest version
- Upgraded third party libraries

- Updated dependencies
  - @backstage/catalog-model@^1.7.0 
  - @backstage/core-components@^0.15.1 
  - @backstage/core-plugin-api@^1.10.0 
  - @backstage/errors@^1.2.4 
  - @backstage/plugin-catalog-react@^1.14.0 
  - @backstage/plugin-permission-react@^0.4.27 
  - @backstage/theme@^0.6.0",
  - @material-ui/core@^4.12.4
  - @material-ui/icons@^4.11.3
  - react-use@^17.5.1
  - react@^16.13.1 || ^17.0.0 || ^18.0.2
  - react-dom@^16.13.1 || ^17.0.0 || ^18.0.2
  - react-router-dom@6.0.0-beta.0 || ^6.3.0
  - @backstage/cli@^0.28.0"
  - @backstage/core-app-api@^1.15.1
  - @backstage/dev-utils@^1.1.2
  - @backstage/test-utils@^1.7.0 
  - @testing-library/jest-dom@^6.6.1
  - @testing-library/react@^16.0.1 
  - @testing-library/user-event@^14.5.2 
  - husky@^9.1.6 
  - lint-staged@^15.2.10 
  - msw@^1.3.4"
  - prettier@3.3.3
  - typescript@~5.6.3
  - @types/react@^18
  - @types/react-dom@^18

- All steps below must be completed prior to merging.

## Author Checklist

### Required

- [x] PR title should follows correct format.
  - MAJOR Release is used when there are breaking changes involved
  - MINOR Release is used when enhancements are introduced
  - PATCH Release is used for defects, security, tech chores, etc.
  - Note:
    - Based on the commit messages, increment the version from the latest release.
    - Push the bumped npm version in package.json back into the repo.
    - Push a tag for the new version back into the repo.
    - [For more details on versioning](https://github.com/phips28/gh-action-bump-version/blob/master/README.md) 
- [x] Checklist of **changes made** added to PR description
- [x] Related issue(s) linked to PR

 
## Reviewer Checklist

- [x] Author checklist has been reviewed?
- [x] All acceptance criteria has been met from linked issue
- [x] Run code locally and verify all changes


## Related Issue(s)

1) S-111245 - Library upgrades - Backstage Deploy Plugins 